### PR TITLE
encode() returns error code if save_file() cannot open output file.

### DIFF
--- a/lodepng.cpp
+++ b/lodepng.cpp
@@ -5938,10 +5938,12 @@ void load_file(std::vector<unsigned char>& buffer, const std::string& filename)
 }
 
 /*write given buffer to the file, overwriting the file, it doesn't append to it.*/
-void save_file(const std::vector<unsigned char>& buffer, const std::string& filename)
+unsigned save_file(const std::vector<unsigned char>& buffer, const std::string& filename)
 {
   std::ofstream file(filename.c_str(), std::ios::out|std::ios::binary);
+  if(!file) return 79;
   file.write(buffer.empty() ? 0 : (char*)&buffer[0], std::streamsize(buffer.size()));
+  return 0;
 }
 #endif /* LODEPNG_COMPILE_DISK */
 
@@ -6127,7 +6129,7 @@ unsigned encode(const std::string& filename,
 {
   std::vector<unsigned char> buffer;
   unsigned error = encode(buffer, in, w, h, colortype, bitdepth);
-  if(!error) save_file(buffer, filename);
+  if(!error) error = save_file(buffer, filename);
   return error;
 }
 

--- a/lodepng.h
+++ b/lodepng.h
@@ -855,7 +855,7 @@ void load_file(std::vector<unsigned char>& buffer, const std::string& filename);
 Save the binary data in an std::vector to a file on disk. The file is overwritten
 without warning.
 */
-void save_file(const std::vector<unsigned char>& buffer, const std::string& filename);
+unsigned save_file(const std::vector<unsigned char>& buffer, const std::string& filename);
 #endif /* LODEPNG_COMPILE_DISK */
 #endif /* LODEPNG_COMPILE_PNG */
 


### PR DESCRIPTION
Before this change, encode() would return 0 whether or not the output
file was created.  There was no way for a caller to know when the
file could not be created (e.g. due to a non-existent parent directory).

Changed save_file() to return error 79 if it cannot open output file.
encode() checks return code from save_file() and passes any error value
back to the caller.