### PR TITLE
Fix VS2015 compilation of pngdetail.

### DIFF
--- a/pngdetail.cpp
+++ b/pngdetail.cpp
@@ -49,6 +49,7 @@ everything except huge output:
 #include <iostream>
 #include <iomanip>
 #include <sstream>
+#include <algorithm>
 
 struct Options
 {


### PR DESCRIPTION
VS2015 can't find std::min/max without additional header.