### PR TITLE
Fixed crash on uncompressed PNG files.

### DIFF
--- a/lodepng.cpp
+++ b/lodepng.cpp
@@ -1768,7 +1768,7 @@ static unsigned deflateDynamic(ucvector* out, size_t* bp, Hash* hash,
     else
     {
       if(!uivector_resize(&lz77_encoded, datasize)) ERROR_BREAK(83 /*alloc fail*/);
-      for(i = datapos; i < dataend; ++i) lz77_encoded.data[i] = data[i]; /*no LZ77, but still will be Huffman compressed*/
+      for(i = datapos; i < dataend; ++i) lz77_encoded.data[i-datapos] = data[i]; /*no LZ77, but still will be Huffman compressed*/
     }
 
     if(!uivector_resizev(&frequencies_ll, 286, 0)) ERROR_BREAK(83 /*alloc fail*/);


### PR DESCRIPTION
When writing an uncompressed PNG, deflateDynamic erroneously indexed a newly allocated block of datasize length using the datapos offset. This would crash anytime datapos > 0.