### PR TITLE
Fix wrong error code if huffmanDecodeSymbol fail

### DIFF
--- a/lodepng.cpp
+++ b/lodepng.cpp
@@ -1171,7 +1171,7 @@ static unsigned inflateHuffmanBlock(ucvector* out, const unsigned char* in, size
       code_d = huffmanDecodeSymbol(in, bp, &tree_d, inbitlength);
       if(code_d > 29)
       {
-        if(code_ll == (unsigned)(-1)) /*huffmanDecodeSymbol returns (unsigned)(-1) in case of error*/
+        if(code_d == (unsigned)(-1)) /*huffmanDecodeSymbol returns (unsigned)(-1) in case of error*/
         {
           /*return error code 10 or 11 depending on the situation that happened in huffmanDecodeSymbol
           (10=no endcode, 11=wrong jump outside of tree)*/


### PR DESCRIPTION
The return value of huffmanDecodeSymbol is stored in code_d not code_ll,
code_ll is between 257 and 285 here.