### PR TITLE
fix compiler warnings about const-breaking cast

### DIFF
--- a/lodepng.cpp
+++ b/lodepng.cpp
@@ -398,7 +398,7 @@ unsigned lodepng_save_file(const unsigned char* buffer, size_t buffersize, const
   FILE* file;
   file = fopen(filename, "wb" );
   if(!file) return 79;
-  fwrite((char*)buffer , 1 , buffersize, file);
+  fwrite(buffer, 1, buffersize, file);
   fclose(file);
   return 0;
 }


### PR DESCRIPTION
`buffer` is already declared as `const unsigned char*`, which can be
transparently accepted by `fwrite()`. Casting it to `char*` here just
makes compilers complain about "discarding cv-qualifiers", so this
commit removes that cast.