### PR TITLE
Added a CMakeLists.txt for using the project as a library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,11 @@
+project(lodepng)
+
+set (SOURCES
+     lodepng.cpp
+     lodepng_util.cpp
+     pngdetail.cpp
+)
+
+include_directories(${CMAKE_CURRENT_DIRECTORY})
+
+add_library(lodepng STATIC ${SOURCES})


### PR DESCRIPTION
Thanks for the awesome library, I will be using it in my projects. This patch adds the CMakeLists.txt file to the project, the project can be compiled both as a static library and a shared library also can be used in other projects just adding it as a submodule and linking the executable. 