### PR TITLE
Fix missing std::min/max definitions

### DIFF
--- a/lodepng_util.cpp
+++ b/lodepng_util.cpp
@@ -26,6 +26,7 @@ freely, subject to the following restrictions:
 #include "lodepng_util.h"
 #include <iostream>
 #include <cmath>
+#include <algorithm>
 
 namespace lodepng
 {


### PR DESCRIPTION
std::min/max are defined in algorithm, which is missing.
Without the header it won't compile using MSVC.