### PR TITLE
support for customize inflate

### DIFF
--- a/lodepng.h
+++ b/lodepng.h
@@ -267,7 +267,7 @@ struct LodePNGDecompressSettings
   zlib function will call custom_deflate*/
   unsigned (*custom_inflate)(unsigned char**, size_t*,
                              const unsigned char*, size_t,
-                             const LodePNGDecompressSettings*);
+                             const LodePNGDecompressSettings*, size_t outbuffsize);
 
   const void* custom_context; /*optional custom settings for custom functions*/
 };
@@ -637,6 +637,7 @@ typedef struct LodePNGDecoderSettings
 } LodePNGDecoderSettings;
 
 void lodepng_decoder_settings_init(LodePNGDecoderSettings* settings);
+void lodepng_decoder_settings_user_regist(LodePNGDecoderSettings* settings);
 #endif /*LODEPNG_COMPILE_DECODER*/
 
 #ifdef LODEPNG_COMPILE_ENCODER


### PR DESCRIPTION
hi,

I tried to customize inflate () in your library, but actually I could not. Because custom_inflate will always be 0.

Therefore, we propose to add lodepng_decoder_settings_user_regist (). Calling this API before actually handling png first will customize the initialization by lodepng_decoder_settings_init () and will be able to use custom_inflate etc.

Another suggestion is to add size_t outbuffsize to the custom_inflate function. In other deflate implementations such as libdeflate, the memory size secured in the output destination buffer is required as a parameter. If you give 0 to this you can not actually return an error.