### PR TITLE
Fix warnings on const cast correctness

### DIFF
--- a/lodepng.cpp
+++ b/lodepng.cpp
@@ -4052,7 +4052,7 @@ static unsigned readChunk_zTXt(LodePNGInfo* info, const LodePNGDecompressSetting
     length = (unsigned)chunkLength - string2_begin;
     /*will fail if zlib error, e.g. if length is too small*/
     error = zlib_decompress(&decoded.data, &decoded.size,
-                            (unsigned char*)(&data[string2_begin]),
+                            (const unsigned char*)(&data[string2_begin]),
                             length, zlibsettings);
     if(error) break;
     ucvector_push_back(&decoded, 0);
@@ -4132,7 +4132,7 @@ static unsigned readChunk_iTXt(LodePNGInfo* info, const LodePNGDecompressSetting
     if(compressed) {
       /*will fail if zlib error, e.g. if length is too small*/
       error = zlib_decompress(&decoded.data, &decoded.size,
-                              (unsigned char*)(&data[begin]),
+                              (const unsigned char*)(&data[begin]),
                               length, zlibsettings);
       if(error) break;
       if(decoded.allocsize < decoded.size) decoded.allocsize = decoded.size;
@@ -4245,7 +4245,7 @@ static unsigned readChunk_iCCP(LodePNGInfo* info, const LodePNGDecompressSetting
   length = (unsigned)chunkLength - string2_begin;
   ucvector_init(&decoded);
   error = zlib_decompress(&decoded.data, &decoded.size,
-                          (unsigned char*)(&data[string2_begin]),
+                          (const unsigned char*)(&data[string2_begin]),
                           length, zlibsettings);
   if(!error) {
     info->iccp_profile_size = decoded.size;
@@ -4775,7 +4775,7 @@ static unsigned addChunk_zTXt(ucvector* out, const char* keyword, const char* te
   ucvector_push_back(&data, 0); /*compression method: 0*/
 
   error = zlib_compress(&compressed.data, &compressed.size,
-                        (unsigned char*)textstring, textsize, zlibsettings);
+                        (const unsigned char*)textstring, textsize, zlibsettings);
   if(!error) {
     for(i = 0; i != compressed.size; ++i) ucvector_push_back(&data, compressed.data[i]);
     error = addChunk(out, "zTXt", data.data, data.size);
@@ -4808,7 +4808,7 @@ static unsigned addChunk_iTXt(ucvector* out, unsigned compressed, const char* ke
     ucvector compressed_data;
     ucvector_init(&compressed_data);
     error = zlib_compress(&compressed_data.data, &compressed_data.size,
-                          (unsigned char*)textstring, textsize, zlibsettings);
+                          (const unsigned char*)textstring, textsize, zlibsettings);
     if(!error) {
       for(i = 0; i != compressed_data.size; ++i) ucvector_push_back(&data, compressed_data.data[i]);
     }

--- a/lodepng.cpp
+++ b/lodepng.cpp
@@ -4052,7 +4052,7 @@ static unsigned readChunk_zTXt(LodePNGInfo* info, const LodePNGDecompressSetting
     length = (unsigned)chunkLength - string2_begin;
     /*will fail if zlib error, e.g. if length is too small*/
     error = zlib_decompress(&decoded.data, &decoded.size,
-                            (const unsigned char*)(&data[string2_begin]),
+                            &data[string2_begin],
                             length, zlibsettings);
     if(error) break;
     ucvector_push_back(&decoded, 0);


### PR DESCRIPTION
```
../third_party/lodepng/lodepng.cpp:4055:45: warning: cast from 'const unsigned char *' to 'unsigned char *' drops const qualifier [-Wcast-qual]
                            (unsigned char*)(&data[string2_begin]),
                                            ^
../third_party/lodepng/lodepng.cpp:4135:47: warning: cast from 'const unsigned char *' to 'unsigned char *' drops const qualifier [-Wcast-qual]
                              (unsigned char*)(&data[begin]),
                                              ^
../third_party/lodepng/lodepng.cpp:4248:43: warning: cast from 'const unsigned char *' to 'unsigned char *' drops const qualifier [-Wcast-qual]
                          (unsigned char*)(&data[string2_begin]),
                                          ^
../third_party/lodepng/lodepng.cpp:4778:41: warning: cast from 'const char *' to 'unsigned char *' drops const qualifier [-Wcast-qual]
                        (unsigned char*)textstring, textsize, zlibsettings);
                                        ^
../third_party/lodepng/lodepng.cpp:4811:43: warning: cast from 'const char *' to 'unsigned char *' drops const qualifier [-Wcast-qual]
                          (unsigned char*)textstring, textsize, zlibsettings);
                                          ^
5 warnings generated.
```