### PR TITLE
Fix ABI incompatibility when calling a C++ compiled lodepng.cpp from C code or vice versa

### DIFF
--- a/lodepng.h
+++ b/lodepng.h
@@ -743,10 +743,6 @@ typedef struct LodePNGState {
   LodePNGColorMode info_raw; /*specifies the format in which you would like to get the raw pixel buffer*/
   LodePNGInfo info_png; /*info of the PNG image obtained after decoding*/
   unsigned error;
-#ifdef LODEPNG_COMPILE_CPP
-  /* For the lodepng::State subclass. */
-  virtual ~LodePNGState(){}
-#endif
 } LodePNGState;
 
 /*init, cleanup and copy functions to use with this struct*/

--- a/lodepng.h
+++ b/lodepng.h
@@ -969,7 +969,7 @@ class State : public LodePNGState {
   public:
     State();
     State(const State& other);
-    virtual ~State();
+    ~State();
     State& operator=(const State& other);
 };
 


### PR DESCRIPTION
The addition of a virtual destructor to LodePNGState when compiled as C++ causes a vptr to be added at the start of the struct. This results in the members of the struct changing their offset depending on whether they're seen from C or C++ code. Internally the LodePNGState struct is never deleted (as to invoke the virtual destructor) and has no virtual methods called on it so it doesn't need to be virtual. Hence fix the ABI incompatibility by removing the virtual destructor.

A demonstration of the problem using Compiler Explorer: https://godbolt.org/z/UJHBLf. Note that when compiled as C++ the offset of `error` moves 8B further into the struct due to the pointer inserted at the beginning.

Dropping the virtual destructor for LodePNGState also allowed the dropping of the virtual keyword from lodepng::State::~State() as described in the commit message.