### PR TITLE
make lodepng_read32bitInt() and lodepng_get_raw_size_lct() static.

### DIFF
--- a/lodepng.cpp
+++ b/lodepng.cpp
@@ -317,6 +317,7 @@ static char* alloc_string(const char* in) {
 
 /* ////////////////////////////////////////////////////////////////////////// */
 
+static 
 unsigned lodepng_read32bitInt(const unsigned char* buffer) {
   return (unsigned)((buffer[0] << 24u) | (buffer[1] << 16u) | (buffer[2] << 8u) | buffer[3]);
 }
@@ -2601,6 +2602,7 @@ unsigned lodepng_can_have_alpha(const LodePNGColorMode* info) {
       || lodepng_has_palette_alpha(info);
 }
 
+static 
 size_t lodepng_get_raw_size_lct(unsigned w, unsigned h, LodePNGColorType colortype, unsigned bitdepth) {
   size_t bpp = lodepng_get_bpp_lct(colortype, bitdepth);
   size_t n = (size_t)w * (size_t)h;


### PR DESCRIPTION
they aren't declared in lodepng.h and are private to lodepng.c