### PR TITLE
add (unsigned) cast to each byte in lodepng_read32bitInt()

### DIFF
--- a/lodepng.cpp
+++ b/lodepng.cpp
@@ -318,7 +318,7 @@ static char* alloc_string(const char* in) {
 /* ////////////////////////////////////////////////////////////////////////// */
 
 unsigned lodepng_read32bitInt(const unsigned char* buffer) {
-  return (unsigned)((buffer[0] << 24u) | (buffer[1] << 16u) | (buffer[2] << 8u) | buffer[3]);
+  return (((unsigned)buffer[0] << 24u) | ((unsigned)buffer[1] << 16u) | ((unsigned)buffer[2] << 8u) | (unsigned)buffer[3]);
 }
 
 #if defined(LODEPNG_COMPILE_PNG) || defined(LODEPNG_COMPILE_ENCODER)


### PR DESCRIPTION
should fix https://github.com/lvandeve/lodepng/issues/91