### PR TITLE
HuffmanTree_cleanup: change initializer of mask to a real constant constant

### DIFF
--- a/lodepng.cpp
+++ b/lodepng.cpp
@@ -607,7 +607,7 @@ static void HuffmanTree_cleanup(HuffmanTree* tree) {
 /* make table for huffman decoding */
 static unsigned HuffmanTree_makeTable(HuffmanTree* tree) {
   static const unsigned headsize = 1u << FIRSTBITS; /*size of the first table*/
-  static const unsigned mask = headsize - 1u;
+  static const unsigned mask = (1u << FIRSTBITS) /*headsize*/ - 1u;
   size_t i, pointer, size; /*total table size*/
   unsigned* maxlens = (unsigned*)lodepng_malloc(headsize * sizeof(unsigned));
   if(!maxlens) return 83; /*alloc fail*/


### PR DESCRIPTION
fixes build by Watcom.