### PR TITLE
Allow palette for gray alpha.

### DIFF
--- a/lodepng.cpp
+++ b/lodepng.cpp
@@ -3857,7 +3857,7 @@ unsigned auto_choose_color(LodePNGColorMode* mode_out,
   palettebits = n <= 2 ? 1 : (n <= 4 ? 2 : (n <= 16 ? 4 : 8));
   palette_ok = n <= 256 && bits <= 8 && n != 0; /*n==0 means likely numcolors wasn't computed*/
   if(numpixels < n * 2) palette_ok = 0; /*don't add palette overhead if image has only a few pixels*/
-  if(gray_ok && bits <= palettebits) palette_ok = 0; /*gray is less overhead*/
+  if(gray_ok && !alpha && bits <= palettebits) palette_ok = 0; /*gray is less overhead*/
   if(!stats->allow_palette) palette_ok = 0;
 
   if(palette_ok) {

--- a/lodepng_unittest.cpp
+++ b/lodepng_unittest.cpp
@@ -2007,6 +2007,9 @@ void testAutoColorModels() {
   // 8-bit gray+alpha
   std::vector<unsigned char> gray8a;
   for(size_t i = 0; i < 17; i++) addColor(gray8a, i, i, i, i);
+  testAutoColorModel(gray8a, 8, LCT_PALETTE, 8, false);
+  // palette not possible, becomes gray alpha
+  for(size_t i = 0; i < 256; i++) addColor(gray8a, i, i, i, i ^ 1);
   testAutoColorModel(gray8a, 8, LCT_GREY_ALPHA, 8, false);
 
   // 16-bit gray+alpha


### PR DESCRIPTION
Gray is only less overhead than palette when there's no alpha channel.

Noticed a regression on gray alpha pngs when testing latest zopfli, this is introduced in https://github.com/lvandeve/lodepng/commit/1d1b55c071591d9537bf5adf67af8d473af6beb8