### PR TITLE
Remove lodepng_auto_choose_color prototype

### DIFF
--- a/lodepng.h
+++ b/lodepng.h
@@ -697,17 +697,6 @@ void lodepng_color_stats_init(LodePNGColorStats* stats);
 void lodepng_compute_color_stats(LodePNGColorStats* stats,
                                  const unsigned char* image, unsigned w, unsigned h,
                                  const LodePNGColorMode* mode_in);
-/*Computes a minimal PNG color model that can contain all colors as indicated by the stats and it settings.
-The stats should be computed with lodepng_compute_color_stats.
-mode_in is raw color profile of the image the stats were computed on, to copy palette order from when relevant.
-Minimal PNG color model means the color type and bit depth that gives smallest amount of bits in the output image,
-e.g. gray if only grayscale pixels, palette if less than 256 colors, color key if only single transparent color, ...
-LodePNG uses this function internally if auto_convert is enabled (it is by default).
-*/
-unsigned lodepng_auto_choose_color(LodePNGColorMode* mode_out,
-                                   const LodePNGColorMode* mode_in,
-                                   const LodePNGColorMode* stats);
-
 /*Settings for the encoder.*/
 typedef struct LodePNGEncoderSettings {
   LodePNGCompressSettings zlibsettings; /*settings for the zlib encoder, such as window size, ...*/


### PR DESCRIPTION
`lodepng_auto_choose_color` definition was removed on 430268baa882a707c36b356402b94ab14dc08b69.
Removing orphan prototype.