### PR TITLE
Drop >= LFS_ZERO (always true, generates warning)

### DIFF
--- a/lodepng.cpp
+++ b/lodepng.cpp
@@ -5434,7 +5434,7 @@ static unsigned filter(unsigned char* out, const unsigned char* in, unsigned w, 
 
   if(bpp == 0) return 31; /*error: invalid color type*/
 
-  if(strategy >= LFS_ZERO && strategy <= LFS_FOUR) {
+  if(strategy <= LFS_FOUR) {
     unsigned char type = (unsigned char)strategy;
     for(y = 0; y != h; ++y) {
       size_t outindex = (1 + linebytes) * y; /*the extra filterbyte added to each row*/


### PR DESCRIPTION
On the line that says:

     if(strategy >= LFS_ZERO && strategy <= LFS_FOUR) {

If compiler warnings are turned up, they will give:

    lodepng.cpp: In function ‘filter’:
    lodepng.cpp:5437:3: error: comparison of unsigned expression >= 0 is always true [-Werror=type-limits]

It's not a terribly useful warning here.  But it is in some cases informative and can catch misunderstandings, so nice to not have to disable it in a build that treats warnings as errors.