### PR TITLE
Add support for non-ASCII filenames under Windows

### DIFF
--- a/lodepng.h
+++ b/lodepng.h
@@ -94,6 +94,16 @@ source files with custom allocators.*/
 #include <string>
 #endif /*LODEPNG_COMPILE_CPP*/
 
+#ifdef LODEPNG_COMPILE_DISK
+#ifdef _WIN32
+#ifdef _MSC_VER 
+#ifndef LODEPNG_NO_WIDE_CHAR_OVERLOADS
+#define LODEPNG_WIDE_CHAR_OVERLOADS
+#endif /*LODEPNG_NO_WIDE_CHAR_OVERLOADS*/
+#endif /*_MSC_VER*/
+#endif /*_WIN32*/
+#endif /*LODEPNG_COMPILE_DISK*/
+
 #ifdef LODEPNG_COMPILE_PNG
 /*The PNG color types (also used for raw image).*/
 typedef enum LodePNGColorType {
@@ -154,6 +164,25 @@ unsigned lodepng_decode32_file(unsigned char** out, unsigned* w, unsigned* h,
 /*Same as lodepng_decode_file, but always decodes to 24-bit RGB raw image.*/
 unsigned lodepng_decode24_file(unsigned char** out, unsigned* w, unsigned* h,
                                const char* filename);
+
+#ifdef LODEPNG_WIDE_CHAR_OVERLOADS
+/*
+Load PNG from disk, from file with given name.
+Same as the other decode functions, but instead takes a filename as input.
+Filename is accepted as a wchar_t pointer.
+*/
+unsigned lodepng_decode_file_w(unsigned char** out, unsigned* w, unsigned* h,
+                               const wchar_t* filename,
+                               LodePNGColorType colortype, unsigned bitdepth);
+
+/*Same as lodepng_decode_file, but always decodes to 32-bit RGBA raw image.*/
+unsigned lodepng_decode32_file_w(unsigned char** out, unsigned* w, unsigned* h,
+                                 const wchar_t* filename);
+
+/*Same as lodepng_decode_file, but always decodes to 24-bit RGB raw image.*/
+unsigned lodepng_decode24_file_w(unsigned char** out, unsigned* w, unsigned* h,
+                                 const wchar_t* filename);
+#endif /*LODEPNG_WIDE_CHAR_OVERLOADS*/
 #endif /*LODEPNG_COMPILE_DISK*/
 #endif /*LODEPNG_COMPILE_DECODER*/
 
@@ -204,6 +233,26 @@ unsigned lodepng_encode32_file(const char* filename,
 /*Same as lodepng_encode_file, but always encodes from 24-bit RGB raw image.*/
 unsigned lodepng_encode24_file(const char* filename,
                                const unsigned char* image, unsigned w, unsigned h);
+
+#ifdef LODEPNG_WIDE_CHAR_OVERLOADS
+/*
+Converts raw pixel data into a PNG file on disk.
+Same as the other encode functions, but instead takes a filename as output.
+Filename is accepted as a wchar_t pointer.
+NOTE: This overwrites existing files without warning!
+*/
+unsigned lodepng_encode_file_w(const wchar_t* filename,
+                               const unsigned char* image, unsigned w, unsigned h,
+                               LodePNGColorType colortype, unsigned bitdepth);
+
+/*Same as lodepng_encode_file, but always encodes from 32-bit RGBA raw image.*/
+unsigned lodepng_encode32_file_w(const wchar_t* filename,
+                                 const unsigned char* image, unsigned w, unsigned h);
+
+/*Same as lodepng_encode_file, but always encodes from 24-bit RGB raw image.*/
+unsigned lodepng_encode24_file_w(const wchar_t* filename,
+                                 const unsigned char* image, unsigned w, unsigned h);
+#endif /*LODEPNG_WIDE_CHAR_OVERLOADS*/
 #endif /*LODEPNG_COMPILE_DISK*/
 #endif /*LODEPNG_COMPILE_ENCODER*/
 
@@ -227,6 +276,16 @@ Same as the other decode functions, but instead takes a filename as input.
 unsigned decode(std::vector<unsigned char>& out, unsigned& w, unsigned& h,
                 const std::string& filename,
                 LodePNGColorType colortype = LCT_RGBA, unsigned bitdepth = 8);
+#ifdef LODEPNG_WIDE_CHAR_OVERLOADS
+/*
+Converts PNG file from disk to raw pixel data in memory.
+Same as the other decode functions, but instead takes a filename as input.
+Filename is accepted as a wchar_t pointer.
+*/
+unsigned decode(std::vector<unsigned char>& out, unsigned& w, unsigned& h,
+                const std::wstring& filename,
+                LodePNGColorType colortype = LCT_RGBA, unsigned bitdepth = 8);
+#endif /*LODEPNG_WIDE_CHAR_OVERLOADS*/
 #endif /*LODEPNG_COMPILE_DISK*/
 #endif /*LODEPNG_COMPILE_DECODER*/
 
@@ -251,6 +310,20 @@ unsigned encode(const std::string& filename,
 unsigned encode(const std::string& filename,
                 const std::vector<unsigned char>& in, unsigned w, unsigned h,
                 LodePNGColorType colortype = LCT_RGBA, unsigned bitdepth = 8);
+#ifdef LODEPNG_WIDE_CHAR_OVERLOADS
+/*
+Converts 32-bit RGBA raw pixel data into a PNG file on disk.
+Same as the other encode functions, but instead takes a filename as output.
+Filename is accepted as a wchar_t pointer.
+NOTE: This overwrites existing files without warning!
+*/
+unsigned encode(const std::wstring& filename,
+                const unsigned char* in, unsigned w, unsigned h,
+                LodePNGColorType colortype = LCT_RGBA, unsigned bitdepth = 8);
+unsigned encode(const std::wstring& filename,
+                const std::vector<unsigned char>& in, unsigned w, unsigned h,
+                LodePNGColorType colortype = LCT_RGBA, unsigned bitdepth = 8);
+#endif /*LODEPNG_WIDE_CHAR_OVERLOADS*/
 #endif /*LODEPNG_COMPILE_DISK*/
 #endif /*LODEPNG_COMPILE_ENCODER*/
 } /* namespace lodepng */
@@ -953,6 +1026,18 @@ return value: error code (0 means ok)
 */
 unsigned lodepng_load_file(unsigned char** out, size_t* outsize, const char* filename);
 
+#ifdef LODEPNG_WIDE_CHAR_OVERLOADS
+/*
+Load a file from disk into buffer. The function allocates the out buffer, and
+after usage you should free it.
+out: output parameter, contains pointer to loaded buffer.
+outsize: output parameter, size of the allocated out buffer
+filename: the path to the file to load. It is accepted as a wchar_t pointer
+return value: error code (0 means ok)
+*/
+unsigned lodepng_load_file_w(unsigned char** out, size_t* outsize, const wchar_t* filename);
+#endif /*LODEPNG_WIDE_CHAR_OVERLOADS*/
+
 /*
 Save a file from buffer to disk. Warning, if it exists, this function overwrites
 the file without warning!
@@ -962,6 +1047,18 @@ filename: the path to the file to save to
 return value: error code (0 means ok)
 */
 unsigned lodepng_save_file(const unsigned char* buffer, size_t buffersize, const char* filename);
+
+#ifdef LODEPNG_WIDE_CHAR_OVERLOADS
+/*
+Save a file from buffer to disk. Warning, if it exists, this function overwrites
+the file without warning!
+buffer: the buffer to write
+buffersize: size of the buffer to write
+filename: the path to the file to save to. It is accepted as a wchar_t pointer
+return value: error code (0 means ok)
+*/
+unsigned lodepng_save_file_w(const unsigned char* buffer, size_t buffersize, const wchar_t* filename);
+#endif /*LODEPNG_WIDE_CHAR_OVERLOADS*/
 #endif /*LODEPNG_COMPILE_DISK*/
 
 #ifdef LODEPNG_COMPILE_CPP
@@ -1008,6 +1105,20 @@ Save the binary data in an std::vector to a file on disk. The file is overwritte
 without warning.
 */
 unsigned save_file(const std::vector<unsigned char>& buffer, const std::string& filename);
+
+#ifdef LODEPNG_WIDE_CHAR_OVERLOADS
+/*
+Load a file from disk into an std::vector.
+return value: error code (0 means ok)
+*/
+unsigned load_file(std::vector<unsigned char>& buffer, const std::wstring& filename);
+
+/*
+Save the binary data in an std::vector to a file on disk. The file is overwritten
+without warning.
+*/
+unsigned save_file(const std::vector<unsigned char>& buffer, const std::wstring& filename);
+#endif /*LODEPNG_WIDE_CHAR_OVERLOADS*/
 #endif /*LODEPNG_COMPILE_DISK*/
 #endif /*LODEPNG_COMPILE_PNG*/
 


### PR DESCRIPTION
This library uses `const char*` (`std::string` for C++ function) as an input type for filenames.
This works great under `*nix` systems, but fails to access files with non-ANSI characters in their paths when used under Windows (MSVC). This is caused by the fact that Windows uses `utf-16` internally (instead of `*nix`'s `utf-8`), characters of which cannot be stored in 8 bytes (`char`). To fix this issue, `wchar_t` needs to be used.

So, I implemented overloads for every function accepting filename, which are only available with `MSVC` (if `_MSC_VER ` is defined in the environment) toolkit under Windows (if `_WIN32` is defined), if `LODEPNG_NO_COMPILE_DISK` is not defined.

These overloads can, additionally be disabled by defining `LODEPNG_NO_WIDE_CHAR_OVERLOADS`.

I'm open to any suggestions and will try to implement additional fixes to the PR if proposed. 

Looking forward to the reply.

P. S. I've additionally took liberty to fix (just run regex-powered auto-replace) an inconsistency in `#endif` commentaries where some of which were defined as `#endif  /* LODEPNG_COMPILE_DISK */` even though most of them were formatted as `#endif  /*LODEPNG_COMPILE_DISK*/`.