### PR TITLE
Typos in example programs

### DIFF
--- a/examples/example_bmp2png.cpp
+++ b/examples/example_bmp2png.cpp
@@ -97,7 +97,7 @@ unsigned decodeBMP(std::vector<unsigned char>& image, unsigned& w, unsigned& h, 
 
 int main(int argc, char *argv[]) {
   if(argc < 3) {
-    std::cout << "Please provice input PNG and output BMP file names" << std::endl;
+    std::cout << "Please provide input PNG and output BMP file names" << std::endl;
     return 0;
   }
 

--- a/examples/example_bmp2png.cpp
+++ b/examples/example_bmp2png.cpp
@@ -97,7 +97,7 @@ unsigned decodeBMP(std::vector<unsigned char>& image, unsigned& w, unsigned& h, 
 
 int main(int argc, char *argv[]) {
   if(argc < 3) {
-    std::cout << "Please provide input PNG and output BMP file names" << std::endl;
+    std::cout << "Please provide input BMP and output PNG file names" << std::endl;
     return 0;
   }
 

--- a/examples/example_encode.c
+++ b/examples/example_encode.c
@@ -30,7 +30,7 @@ freely, subject to the following restrictions:
 
 /*
 3 ways to encode a PNG from RGBA pixel data to a file (and 2 in-memory ways).
-NOTE: this samples overwrite the file or test.png without warning!
+NOTE: these samples overwrite the file or test.png without warning!
 */
 
 /*

--- a/examples/example_encode.cpp
+++ b/examples/example_encode.cpp
@@ -28,7 +28,7 @@ freely, subject to the following restrictions:
 
 /*
 3 ways to encode a PNG from RGBA pixel data to a file (and 2 in-memory ways).
-NOTE: this samples overwrite the file or test.png without warning!
+NOTE: these samples overwrite the file or test.png without warning!
 */
 
 //g++ lodepng.cpp examples/example_encode.cpp -I./ -ansi -pedantic -Wall -Wextra -O3

--- a/examples/example_png2bmp.cpp
+++ b/examples/example_png2bmp.cpp
@@ -101,7 +101,7 @@ void encodeBMP(std::vector<unsigned char>& bmp, const unsigned char* image, int 
 
 int main(int argc, char *argv[]) {
   if(argc < 3) {
-    std::cout << "Please provice input PNG and output BMP file names" << std::endl;
+    std::cout << "Please provide input PNG and output BMP file names" << std::endl;
     return 0;
   }
   const char* infile = argv[1];


### PR DESCRIPTION
1. Two occurrences of "this samples" in ``example_encode.c`` and ``example_encode.cpp`` in a warning about overwriting files. This warning applies to all the examples, and should thus be "these samples".

2. Two typos of "provide" and one swap of BMP/PNG, as noted in https://github.com/lvandeve/lodepng/issues/132