### PR TITLE
Fix undefined behavior found by UBSan fuzzing

### DIFF
--- a/lodepng.cpp
+++ b/lodepng.cpp
@@ -1367,8 +1367,11 @@ static unsigned inflateNoCompression(ucvector* out, LodePNGBitReader* reader,
   /*read the literal data: LEN bytes are now stored in the out buffer*/
   if(bytepos + LEN > size) return 23; /*error: reading outside of in buffer*/
 
-  lodepng_memcpy(out->data + out->size - LEN, reader->data + bytepos, LEN);
-  bytepos += LEN;
+  /*out->data can be NULL (when LEN is zero), and arithmetics on NULL ptr is undefined. so we check*/
+  if (out->data) {
+    lodepng_memcpy(out->data + out->size - LEN, reader->data + bytepos, LEN);
+    bytepos += LEN;
+  }
 
   reader->bp = bytepos << 3u;
 


### PR DESCRIPTION
If you build an executable using lodepng with `-g -Og -fsanitize=address,undefined -fsanitize-no-recover=all` in CFLAGS and try to load [this image file](https://github.com/hpjansson/chafa/blob/master/tests/data/bad/lodepng-zero-length-literal.png), the program will abort with the following output:

```
lodepng.c:1370:28: runtime error: applying zero offset to null pointer
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior lodepng.c:1370:28
```

The fix is to check for a NULL pointer before trying to do calculations with it.