### PR TITLE
Continue early to avoid uninitialized value

### DIFF
--- a/lodepng.cpp
+++ b/lodepng.cpp
@@ -711,10 +711,10 @@ static unsigned HuffmanTree_makeTable(HuffmanTree* tree) {
   numpresent = 0;
   for(i = 0; i < tree->numcodes; ++i) {
     unsigned l = tree->lengths[i];
+    if(l == 0) continue;
     unsigned symbol = tree->codes[i]; /*the huffman bit pattern. i itself is the value.*/
     /*reverse bits, because the huffman bits are given in MSB first order but the bit reader reads LSB first*/
     unsigned reverse = reverseBits(symbol, l);
-    if(l == 0) continue;
     numpresent++;
 
     if(l <= FIRSTBITS) {


### PR DESCRIPTION
If l == 0 we don't need to load symbol and call reverseBits.
However if we do, symbol is uninitialized and function call
with uninitialized argument and behavior is undefined.