### PR TITLE
Set hard limit for image buffer size

### DIFF
--- a/lodepng.h
+++ b/lodepng.h
@@ -30,6 +30,10 @@ freely, subject to the following restrictions:
 
 extern const char* LODEPNG_VERSION_STRING;
 
+/*Hard upper limit on size of an uncompressed in-memory image buffer. The
+total memory consumption may be higher, e.g. during postProcessScanlines().*/
+#define LODEPNG_IMAGE_DATA_SIZE_MAX 0xffffffffU
+
 /*
 The following #defines are used to create code sections. They can be disabled
 to disable code sections, which can give faster compile time and smaller binary.


### PR DESCRIPTION
A security researcher found that it was possible to make lodepng allocate a terabyte or more of memory by supplying bogus image dimensions. This adds a compiled-in upper limit on the size of the allocation for uncompressed image data.

Maybe you want this to be configurable at runtime (possibly by generalizing zlibsettings->max_output_size). Any solution works for me as long as it's possible to specify a limit :-)
