### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ This shows compiler flags it was designed for, but normally one would use the
 compiler or build system of their project instead of those commands, and other
 C compilers are supported.
 
+### Building lodepng - Using vcpkg
+
+You can download and install lodepng using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install lodepng
+
+The lodepng port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ### Makefile
 
 There is a Makefile, but this is not intended for using LodePNG itself since the


### PR DESCRIPTION
lodepng is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for lodepng and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build lodepng, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/lodepng/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)