### PR TITLE
Minor LodePNG optimizations

### DIFF
--- a/lodepng.cpp
+++ b/lodepng.cpp
@@ -3256,33 +3256,28 @@ static void getPixelColorRGBA8(unsigned char* r, unsigned char* g,
   if(mode->colortype == LCT_GREY) {
     if(mode->bitdepth == 8) {
       *r = *g = *b = in[i];
-      if(mode->key_defined && *r == mode->key_r) *a = 0;
-      else *a = 255;
+      *a = 255 * !(mode->key_defined && *r == mode->key_r);
     } else if(mode->bitdepth == 16) {
       *r = *g = *b = in[i * 2 + 0];
-      if(mode->key_defined && 256U * in[i * 2 + 0] + in[i * 2 + 1] == mode->key_r) *a = 0;
-      else *a = 255;
+      *a = 255 * !(mode->key_defined && 256U * in[i * 2 + 0] + in[i * 2 + 1] == mode->key_r);
     } else {
       unsigned highest = ((1U << mode->bitdepth) - 1U); /*highest possible value for this bit depth*/
       size_t j = i * mode->bitdepth;
       unsigned value = readBitsFromReversedStream(&j, in, mode->bitdepth);
       *r = *g = *b = (value * 255) / highest;
-      if(mode->key_defined && value == mode->key_r) *a = 0;
-      else *a = 255;
+      *a = 255 * !(mode->key_defined && value == mode->key_r);
     }
   } else if(mode->colortype == LCT_RGB) {
     if(mode->bitdepth == 8) {
       *r = in[i * 3 + 0]; *g = in[i * 3 + 1]; *b = in[i * 3 + 2];
-      if(mode->key_defined && *r == mode->key_r && *g == mode->key_g && *b == mode->key_b) *a = 0;
-      else *a = 255;
+      *a = 255 * !(mode->key_defined && *r == mode->key_r && *g == mode->key_g && *b == mode->key_b);
     } else {
       *r = in[i * 6 + 0];
       *g = in[i * 6 + 2];
       *b = in[i * 6 + 4];
-      if(mode->key_defined && 256U * in[i * 6 + 0] + in[i * 6 + 1] == mode->key_r
+      *a = 255 * !(mode->key_defined && 256U * in[i * 6 + 0] + in[i * 6 + 1] == mode->key_r
          && 256U * in[i * 6 + 2] + in[i * 6 + 3] == mode->key_g
-         && 256U * in[i * 6 + 4] + in[i * 6 + 5] == mode->key_b) *a = 0;
-      else *a = 255;
+         && 256U * in[i * 6 + 4] + in[i * 6 + 5] == mode->key_b);
     }
   } else if(mode->colortype == LCT_PALETTE) {
     unsigned index;
@@ -3337,13 +3332,13 @@ static void getPixelColorsRGBA8(unsigned char* LODEPNG_RESTRICT buffer, size_t n
       if(mode->key_defined) {
         buffer -= numpixels * num_channels;
         for(i = 0; i != numpixels; ++i, buffer += num_channels) {
-          if(buffer[0] == mode->key_r) buffer[3] = 0;
+          buffer[3] *= !(buffer[0] == mode->key_r);
         }
       }
     } else if(mode->bitdepth == 16) {
       for(i = 0; i != numpixels; ++i, buffer += num_channels) {
         buffer[0] = buffer[1] = buffer[2] = in[i * 2];
-        buffer[3] = mode->key_defined && 256U * in[i * 2 + 0] + in[i * 2 + 1] == mode->key_r ? 0 : 255;
+        buffer[3] = 255 * !(mode->key_defined && 256U * in[i * 2 + 0] + in[i * 2 + 1] == mode->key_r);
       }
     } else {
       unsigned highest = ((1U << mode->bitdepth) - 1U); /*highest possible value for this bit depth*/
@@ -3351,7 +3346,7 @@ static void getPixelColorsRGBA8(unsigned char* LODEPNG_RESTRICT buffer, size_t n
       for(i = 0; i != numpixels; ++i, buffer += num_channels) {
         unsigned value = readBitsFromReversedStream(&j, in, mode->bitdepth);
         buffer[0] = buffer[1] = buffer[2] = (value * 255) / highest;
-        buffer[3] = mode->key_defined && value == mode->key_r ? 0 : 255;
+        buffer[3] = 255 * !(mode->key_defined && value == mode->key_r);
       }
     }
   } else if(mode->colortype == LCT_RGB) {
@@ -3363,7 +3358,7 @@ static void getPixelColorsRGBA8(unsigned char* LODEPNG_RESTRICT buffer, size_t n
       if(mode->key_defined) {
         buffer -= numpixels * num_channels;
         for(i = 0; i != numpixels; ++i, buffer += num_channels) {
-          if(buffer[0] == mode->key_r && buffer[1]== mode->key_g && buffer[2] == mode->key_b) buffer[3] = 0;
+          buffer[3] *= !(buffer[0] == mode->key_r && buffer[1]== mode->key_g && buffer[2] == mode->key_b);
         }
       }
     } else {
@@ -3371,10 +3366,10 @@ static void getPixelColorsRGBA8(unsigned char* LODEPNG_RESTRICT buffer, size_t n
         buffer[0] = in[i * 6 + 0];
         buffer[1] = in[i * 6 + 2];
         buffer[2] = in[i * 6 + 4];
-        buffer[3] = mode->key_defined
+        buffer[3] = 255 * !(mode->key_defined
            && 256U * in[i * 6 + 0] + in[i * 6 + 1] == mode->key_r
            && 256U * in[i * 6 + 2] + in[i * 6 + 3] == mode->key_g
-           && 256U * in[i * 6 + 4] + in[i * 6 + 5] == mode->key_b ? 0 : 255;
+           && 256U * in[i * 6 + 4] + in[i * 6 + 5] == mode->key_b);
       }
     }
   } else if(mode->colortype == LCT_PALETTE) {
@@ -3497,17 +3492,15 @@ static void getPixelColorRGBA16(unsigned short* r, unsigned short* g, unsigned s
                                 const unsigned char* in, size_t i, const LodePNGColorMode* mode) {
   if(mode->colortype == LCT_GREY) {
     *r = *g = *b = 256 * in[i * 2 + 0] + in[i * 2 + 1];
-    if(mode->key_defined && 256U * in[i * 2 + 0] + in[i * 2 + 1] == mode->key_r) *a = 0;
-    else *a = 65535;
+    *a = 65535 * !(mode->key_defined && 256U * in[i * 2 + 0] + in[i * 2 + 1] == mode->key_r);
   } else if(mode->colortype == LCT_RGB) {
     *r = 256u * in[i * 6 + 0] + in[i * 6 + 1];
     *g = 256u * in[i * 6 + 2] + in[i * 6 + 3];
     *b = 256u * in[i * 6 + 4] + in[i * 6 + 5];
-    if(mode->key_defined
+    *a = 65535 *!(mode->key_defined
        && 256u * in[i * 6 + 0] + in[i * 6 + 1] == mode->key_r
        && 256u * in[i * 6 + 2] + in[i * 6 + 3] == mode->key_g
-       && 256u * in[i * 6 + 4] + in[i * 6 + 5] == mode->key_b) *a = 0;
-    else *a = 65535;
+       && 256u * in[i * 6 + 4] + in[i * 6 + 5] == mode->key_b);
   } else if(mode->colortype == LCT_GREY_ALPHA) {
     *r = *g = *b = 256u * in[i * 4 + 0] + in[i * 4 + 1];
     *a = 256u * in[i * 4 + 2] + in[i * 4 + 3];

--- a/lodepng_benchmark.cpp
+++ b/lodepng_benchmark.cpp
@@ -23,8 +23,8 @@ freely, subject to the following restrictions:
     distribution.
 */
 
-//g++ lodepng.cpp lodepng_benchmark.cpp -Wall -Wextra -pedantic -ansi -lSDL -O3
-//g++ lodepng.cpp lodepng_benchmark.cpp -Wall -Wextra -pedantic -ansi -lSDL -O3 && ./a.out
+//g++ lodepng.cpp lodepng_benchmark.cpp -Wall -Wextra -pedantic -ansi -lSDL2main -lSDL2 -O3
+//g++ lodepng.cpp lodepng_benchmark.cpp -Wall -Wextra -pedantic -ansi -lSDL2main -lSDL2 -O3 && ./a.out
 
 #include "lodepng.h"
 
@@ -301,7 +301,7 @@ int main(int argc, char *argv[]) {
   if(!do_encode) decode_encoded = false;
 
   if(files.empty()) {
-    std::cout << "must give .png filenames to benchamrk" << std::endl;
+    std::cout << "must give .png filenames to benchmark" << std::endl;
     showHelp(argc, argv);
     return 1;
   }
@@ -350,4 +350,6 @@ int main(int argc, char *argv[]) {
               << " compressed bytes (" << ((total_raw_in_size/1024.0/1024.0)/(total_dec_time/NUM_DECODE)) << " MB/s, "
               << ((total_pixels/1024.0/1024.0)/(total_dec_time/NUM_DECODE)) << " MP/s)" << std::endl;
   }
+
+  return 0;
 }


### PR DESCRIPTION
LodePNG code size is decreased by about 1.5kB when compiled with MSYS2 CLANG64 Clang 15.0.0

Decoding (RGB and non-alpha grey colortypes) and encoding (any colortype) should be about 1-2% faster

A warning is fixed in lodepng_benchmark.cpp so it can successfully be compiled with the recommended build command