### PR TITLE
Shared lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@
 CC ?= gcc
 CXX ?= g++
 
-override CFLAGS := -W -Wall -Wextra -ansi -pedantic -O3 -Wno-unused-function $(CFLAGS)
-override CXXFLAGS := -W -Wall -Wextra -ansi -pedantic -O3 $(CXXFLAGS)
+override CFLAGS := -W -Wall -Wextra -ansi -pedantic -O3 -Wno-unused-function -fPIC $(CFLAGS)
+override CXXFLAGS := -W -Wall -Wextra -ansi -pedantic -O3 -fPIC $(CXXFLAGS)
 
-all: unittest benchmark pngdetail showpng
+all: unittest benchmark pngdetail showpng liblodepng.so
 
 %.o: %.cpp
 	@mkdir -p `dirname $@`
@@ -29,6 +29,9 @@ pngdetail: lodepng.o lodepng_util.o pngdetail.o
 
 showpng: lodepng.o examples/example_sdl.o
 	$(CXX) -I ./ $^ $(CXXFLAGS) -lSDL2 -o $@
+
+liblodepng.so: lodepng.o
+	$(CXX) $(CXXFLAGS) $^ -shared -o $@
 
 clean:
 	rm -f unittest benchmark pngdetail showpng lodepng_unittest.o lodepng_benchmark.o lodepng.o lodepng_util.o pngdetail.o examples/example_sdl.o

--- a/lodepng.h
+++ b/lodepng.h
@@ -28,6 +28,7 @@ freely, subject to the following restrictions:
 
 #include <string.h> /*for size_t*/
 
+extern "C" {
 extern const char* LODEPNG_VERSION_STRING;
 
 /*
@@ -101,6 +102,7 @@ in a comment in the lodepng.c(pp) file in the 'else' case of the searchable LODE
 or comment out LODEPNG_COMPILE_CRC below*/
 #define LODEPNG_COMPILE_CRC
 #endif
+}
 
 /*compile the C++ version (you can disable the C++ wrapper here even when compiling for C++)*/
 #ifdef __cplusplus
@@ -116,6 +118,7 @@ or comment out LODEPNG_COMPILE_CPP below*/
 #include <string>
 #endif /*LODEPNG_COMPILE_CPP*/
 
+extern "C" {
 #ifdef LODEPNG_COMPILE_PNG
 /*The PNG color types (also used for raw image).*/
 typedef enum LodePNGColorType {
@@ -246,6 +249,7 @@ unsigned lodepng_encode24_file(const char* filename,
 #endif /*LODEPNG_COMPILE_DISK*/
 #endif /*LODEPNG_COMPILE_ENCODER*/
 
+}
 
 #ifdef LODEPNG_COMPILE_CPP
 namespace lodepng {
@@ -303,6 +307,7 @@ unsigned encode(const std::string& filename,
 #endif /*LODEPNG_COMPILE_CPP*/
 #endif /*LODEPNG_COMPILE_PNG*/
 
+extern "C" {
 #ifdef LODEPNG_COMPILE_ERROR_TEXT
 /*Returns an English description of the numerical error code.*/
 const char* lodepng_error_text(unsigned code);
@@ -1088,6 +1093,7 @@ to handle such files and encode in-memory
 */
 unsigned lodepng_save_file(const unsigned char* buffer, size_t buffersize, const char* filename);
 #endif /*LODEPNG_COMPILE_DISK*/
+}
 
 #ifdef LODEPNG_COMPILE_CPP
 /* The LodePNG C++ wrapper uses std::vectors instead of manually allocated memory buffers. */


### PR DESCRIPTION
* declare `C` `API` symbols `extern "C"` to allow linking from `C` even if compiled with `C++`
* add a makefile target to build a shared library

rationale: debian packages the library and builds it as shared library. Currently it is not possible to link from `C` applications as the symbols are expored as `C++` symbols.