### PR TITLE
Separate chunk decoding and image decoding & inflation

### DIFF
--- a/lodepng.cpp
+++ b/lodepng.cpp
@@ -27,19 +27,6 @@ freely, subject to the following restrictions:
 The manual and changelog are in the header file "lodepng.h"
 Rename this file to lodepng.cpp to use it for C++, or to lodepng.c to use it for C.
 */
-/*
-This file has been altered from the original. The decodeGeneric function has
-been split into the public lodepng_decode_chunks and static inflateIdat.
-decodeGeneric has been reimplemented by calling these 2 functions. A new
-public lodepng_finish_decode has been added. With the new public functions
-a user can separate decode of all the chunks, so as to learn all the details
-of the file, from decompression, and possible conversion, of the image data.
-Search for msc to see the changes.
-
-Additional warning disables have been added. 4267 for MS VC++ and the
-equivalent -Wshorten-64-to-32 for clang. "32-bit shift implicitly converted
-to 64 bits" warnings have been fixed by changing 1u constants to 1ull.
-*/
 
 #include "lodepng.h"
 
@@ -5298,8 +5285,8 @@ unsigned lodepng_inspect_chunk(LodePNGState* state, size_t pos,
   return error;
 }
 
-/*extracted from the original decodeGeneric by msc*/
 /*read the PNG's chunks, updating the state and accumulating the iDAT chunks*/
+/*extracted from previous version of decodeGeneric*/
 unsigned lodepng_decode_chunks(void** idat_out, size_t* idatsize_out, unsigned* w, unsigned* h,
                                LodePNGState* state,
                                const unsigned char* in, size_t insize) {
@@ -5480,7 +5467,7 @@ unsigned lodepng_decode_chunks(void** idat_out, size_t* idatsize_out, unsigned* 
   return state->error;
 }
 
-/*extracted from the original decodeGeneric by msc*/
+/*extracted from the previous version of decodeGeneric*/
 static unsigned inflateIdat(unsigned char** out,
                             unsigned char* directOut, size_t directOutSize,
                             unsigned w, unsigned h,
@@ -5507,7 +5494,7 @@ static unsigned inflateIdat(unsigned char** out,
     If the decompressed size does not match the prediction, the image must be corrupt.*/
     if(state->info_png.interlace_method == 0) {
       unsigned bpp = lodepng_get_bpp(&state->info_png.color);
-      expected_size = lodepng_get_raw_size_idat(*w, *h, bpp);
+      expected_size = lodepng_get_raw_size_idat(w, h, bpp);
     } else {
       unsigned bpp = lodepng_get_bpp(&state->info_png.color);
       /*Adam-7 interlaced: expected size is the sum of the 7 sub-images sizes*/
@@ -5545,7 +5532,6 @@ static unsigned inflateIdat(unsigned char** out,
   return state->error;
 }
 
-/*added by msc*/
 /*finishes decode by inflating the images captured from the idat chunks by lodepng_decode_chunks
 and converting them if info_raw differs from info_png.color. A buffer to receive the final
 image data is provided as a parameter.
@@ -5585,8 +5571,8 @@ unsigned lodepng_finish_decode(unsigned char* cbuffer, size_t cbufsize,
   return state->error;
 }
 
-/*reimplemented by msc.*/
 /*read a PNG, the result will be in the same color type as the PNG (hence "generic")*/
+/*reimplemented by calling the functions extracted from previous version*/
 static void decodeGeneric(unsigned char** out, unsigned* w, unsigned* h,
                           LodePNGState* state,
                           const unsigned char* in, size_t insize) {
@@ -7110,7 +7096,6 @@ const char* lodepng_error_text(unsigned code) {
     case 120: return "invalid cLLi chunk size";
     case 121: return "invalid chunk type name: may only contain [a-zA-Z]";
     case 122: return "invalid chunk type name: third character must be uppercase";
-    // Added for 'msc' changes
     case 123: return "destination buffer too small";
   }
   return "unknown error code";

--- a/lodepng.h
+++ b/lodepng.h
@@ -23,6 +23,13 @@ freely, subject to the following restrictions:
     distribution.
 */
 
+/*
+This file has been altered from the original. Public lodepng_decode_chunks
+and lodepng_finish_decode functions have been added. With these new functions
+a user can separate decode of all the chunks, so as to learn all the details
+of the file, from decompression, and possible conversion, of the image data.
+Search for msc to see the changes.
+*/
 #ifndef LODEPNG_H
 #define LODEPNG_H
 
@@ -871,6 +878,24 @@ void lodepng_state_copy(LodePNGState* dest, const LodePNGState* source);
 #endif /* defined(LODEPNG_COMPILE_DECODER) || defined(LODEPNG_COMPILE_ENCODER) */
 
 #ifdef LODEPNG_COMPILE_DECODER
+/*
+Read the PNG's chunks, updating the state and accumulating the iDAT chunks.
+idat_out will be set to point to the accumulated iDAT chunks.
+Added by msc.
+*/
+unsigned lodepng_decode_chunks(void** idat_out, size_t* idatsize_out, unsigned* w, unsigned* h,
+                               LodePNGState* state,
+                               const unsigned char* in, size_t insize);
+
+/*
+Inflate the idat accumulated by lodepng_decode_chunks, convert to match
+the state->info_raw color type, if necessary, and return the data in
+the memory pointed to by cbuffer.
+Added by msc.
+ */
+unsigned lodepng_finish_decode(unsigned char* cbuffer, size_t cbufsize,
+                               unsigned w, unsigned h,
+                               LodePNGState* state, void* idat_in, size_t idatsize_in);
 /*
 Same as lodepng_decode_memory, but uses a LodePNGState to allow custom settings and
 getting much more information about the PNG image and color mode.

--- a/lodepng.h
+++ b/lodepng.h
@@ -23,13 +23,6 @@ freely, subject to the following restrictions:
     distribution.
 */
 
-/*
-This file has been altered from the original. Public lodepng_decode_chunks
-and lodepng_finish_decode functions have been added. With these new functions
-a user can separate decode of all the chunks, so as to learn all the details
-of the file, from decompression, and possible conversion, of the image data.
-Search for msc to see the changes.
-*/
 #ifndef LODEPNG_H
 #define LODEPNG_H
 
@@ -974,7 +967,6 @@ void lodepng_state_copy(LodePNGState* dest, const LodePNGState* source);
 /*
 Read the PNG's chunks, updating the state and accumulating the iDAT chunks.
 idat_out will be set to point to the accumulated iDAT chunks.
-Added by msc.
 */
 unsigned lodepng_decode_chunks(void** idat_out, size_t* idatsize_out, unsigned* w, unsigned* h,
                                LodePNGState* state,
@@ -984,7 +976,6 @@ unsigned lodepng_decode_chunks(void** idat_out, size_t* idatsize_out, unsigned* 
 Inflate the idat accumulated by lodepng_decode_chunks, convert to match
 the state->info_raw color type, if necessary, and return the data in
 the memory pointed to by cbuffer.
-Added by msc.
  */
 unsigned lodepng_finish_decode(unsigned char* cbuffer, size_t cbufsize,
                                unsigned w, unsigned h,
@@ -2027,6 +2018,12 @@ symbol.
 
 Not all changes are listed here, the commit history in github lists more:
 https://github.com/lvandeve/lodepng
+
+*) 16 apr 2025: added public lodepng_decode_chunks and lodepng_finish_decode
+   functions. With these a user can separate decode of all the chunks, so as
+   to learn all the details of the file, from decompression, and possible
+   conversion, of the image data.
+*) 16 apr 2025: Separated chunk decoding from image decoding and expansion.
 
 *) 23 dec 2024: added support for the mDCv and cLLi chunks (for png third
    edition spec)


### PR DESCRIPTION
These changes make it possible for the user to first decode of all the chunks, to learn all the details of the image in the file, then decompress, and possibly convert, the image data to the desired format.

My use case is creating KTX containers for GPU textures where, typically, we want to read the image as is, i.e what the hidden `decodeGeneric` function does. In the API prior to this change we had to
1. Read the whole file decoding the image into some format that is likely not the format we want.
2. Determine the format of the image and modify decode parameters to get what we really want.
3. Rewind the file.
4. Read the whole file decoding all the chunks and the image again.

With this change:
1. Decode the chunks by calling `lodepng_decode_chunks`.
2. Determine from the that info and command-line options what format we want.
3. Call `lodepng_finish_decode` to decode the image into the desired format.

Change Details:
- Split the `decodeGeneric` function into the public lodepng_decode_chunks and static inflateIdat.
- Reimplement decodeGeneric to call these 2 functions.
- Add public lodepng_finish_decode function which calls inflateIdat and handles any necessary conversion.
- New warning disables have been added: 4267 for MS VC++ and the equivalent -Wshorten-64-to-32 for clang.
- "32-bit shift implicitly converted to 64 bits" warnings have been fixed by changing `1u` constants to `1ull`.

The warning fixes were made before I updated the code to LodePNG version 20241228. It is possible the disables are no longer needed. IIRC the 20241228 version has an alternate fix for the last warning: casts instead of my `1ull`. I use the casts. 