### PR TITLE
Implemented flags to accept invalid or reserved chunk names

### DIFF
--- a/lodepng.cpp
+++ b/lodepng.cpp
@@ -5423,10 +5423,10 @@ static void decodeGeneric(unsigned char** out, unsigned* w, unsigned* h,
       if(state->error) break;
 #endif /*LODEPNG_COMPILE_ANCILLARY_CHUNKS*/
     } else /*it's not an implemented chunk type, so ignore it: skip over the data*/ {
-      if(!lodepng_chunk_type_name_valid(chunk)) {
+      if(!state->decoder.ignore_invalid_name && !lodepng_chunk_type_name_valid(chunk)) {
         CERROR_BREAK(state->error, 121); /* invalid chunk type name */
       }
-      if(lodepng_chunk_reserved(chunk)) {
+      if(!state->decoder.ignore_reserved_name && lodepng_chunk_reserved(chunk)) {
         CERROR_BREAK(state->error, 122); /* invalid third lowercase character */
       }
 
@@ -5585,6 +5585,8 @@ void lodepng_decoder_settings_init(LodePNGDecoderSettings* settings) {
   settings->remember_unknown_chunks = 0;
   settings->max_text_size = 16777216;
   settings->max_icc_size = 16777216; /* 16MB is much more than enough for any reasonable ICC profile */
+  settings->ignore_invalid_name = 0;
+  settings->ignore_reserved_name = 0;
 #endif /*LODEPNG_COMPILE_ANCILLARY_CHUNKS*/
   settings->ignore_crc = 0;
   settings->ignore_critical = 0;
@@ -6868,9 +6870,12 @@ void lodepng_encoder_settings_init(LodePNGEncoderSettings* settings) {
   settings->auto_convert = 1;
   settings->force_palette = 0;
   settings->predefined_filters = 0;
+  settings->ignore_invalid_name = 0;
+  settings->ignore_reserved_name = 0;
 #ifdef LODEPNG_COMPILE_ANCILLARY_CHUNKS
   settings->add_id = 0;
   settings->text_compression = 1;
+
 #endif /*LODEPNG_COMPILE_ANCILLARY_CHUNKS*/
 }
 

--- a/lodepng.cpp
+++ b/lodepng.cpp
@@ -2837,13 +2837,6 @@ unsigned lodepng_chunk_append(unsigned char** out, size_t* outsize, const unsign
   size_t total_chunk_length, new_length;
   unsigned char *chunk_start, *new_buffer;
 
-  if(!lodepng_chunk_type_name_valid(chunk)) {
-    return 121; /* invalid chunk type name */
-  }
-  if(lodepng_chunk_reserved(chunk)) {
-    return 122; /* invalid third lowercase character */
-  }
-
   if(lodepng_addofl(lodepng_chunk_length(chunk), 12, &total_chunk_length)) return 77;
   if(lodepng_addofl(*outsize, total_chunk_length, &new_length)) return 77;
 
@@ -6439,6 +6432,13 @@ static unsigned preProcessScanlines(unsigned char** out, size_t* outsize, const 
 static unsigned addUnknownChunks(ucvector* out, unsigned char* data, size_t datasize) {
   unsigned char* inchunk = data;
   while((size_t)(inchunk - data) < datasize) {
+    if(!lodepng_chunk_type_name_valid(inchunk)) {
+        return 121; /* invalid chunk type name */
+    }
+    if(lodepng_chunk_reserved(inchunk)) {
+        return 122; /* invalid third lowercase character */
+    }
+
     CERROR_TRY_RETURN(lodepng_chunk_append(&out->data, &out->size, inchunk));
     out->allocsize = out->size; /*fix the allocsize again*/
     inchunk = lodepng_chunk_next(inchunk, data + datasize);

--- a/lodepng.h
+++ b/lodepng.h
@@ -933,13 +933,13 @@ typedef struct LodePNGEncoderSettings {
   NOTE: enabling this may worsen compression if auto_convert is used to choose
   optimal color mode, because it cannot use grayscale color modes in this case*/
   unsigned force_palette;
-  unsigned ignore_invalid_name; /*ignore error when chunk names contain invalid characters*/
-  unsigned ignore_reserved_name; /*ignore error when chunk name has the reserved bit set*/
 #ifdef LODEPNG_COMPILE_ANCILLARY_CHUNKS
   /*add LodePNG identifier and version as a text chunk, for debugging*/
   unsigned add_id;
   /*encode text chunks as zTXt chunks instead of tEXt chunks, and use compression in iTXt chunks*/
   unsigned text_compression;
+  unsigned ignore_invalid_name; /*ignore error when chunk names contain invalid characters*/
+  unsigned ignore_reserved_name; /*ignore error when chunk name has the reserved bit set*/
 
 #endif /*LODEPNG_COMPILE_ANCILLARY_CHUNKS*/
 } LodePNGEncoderSettings;

--- a/lodepng.h
+++ b/lodepng.h
@@ -823,7 +823,6 @@ typedef struct LodePNGDecoderSettings {
      errors: srgb rendering intent value, size of content of ancillary chunks, more than 79 characters for some
      strings, placement/combination rules for ancillary chunks, crc of unknown chunks, allowed characters
      in string keys, invalid characters in chunk types names, etc... */
-
   unsigned color_convert; /*whether to convert the PNG to the color type you want. Default: yes*/
 
 #ifdef LODEPNG_COMPILE_ANCILLARY_CHUNKS
@@ -831,6 +830,9 @@ typedef struct LodePNGDecoderSettings {
 
   /*store all bytes from unknown chunks in the LodePNGInfo (off by default, useful for a png editor)*/
   unsigned remember_unknown_chunks;
+
+  unsigned ignore_invalid_name; /*ignore error when chunk names contain invalid characters*/
+  unsigned ignore_reserved_name; /*ignore error when chunk name has the reserved bit set*/
 
   /* maximum size for decompressed text chunks. If a text chunk's text is larger than this, an error is returned,
   unless reading text chunks is disabled or this limit is set higher or disabled. Set to 0 to allow any size.
@@ -931,11 +933,14 @@ typedef struct LodePNGEncoderSettings {
   NOTE: enabling this may worsen compression if auto_convert is used to choose
   optimal color mode, because it cannot use grayscale color modes in this case*/
   unsigned force_palette;
+  unsigned ignore_invalid_name; /*ignore error when chunk names contain invalid characters*/
+  unsigned ignore_reserved_name; /*ignore error when chunk name has the reserved bit set*/
 #ifdef LODEPNG_COMPILE_ANCILLARY_CHUNKS
   /*add LodePNG identifier and version as a text chunk, for debugging*/
   unsigned add_id;
   /*encode text chunks as zTXt chunks instead of tEXt chunks, and use compression in iTXt chunks*/
   unsigned text_compression;
+
 #endif /*LODEPNG_COMPILE_ANCILLARY_CHUNKS*/
 } LodePNGEncoderSettings;
 

--- a/lodepng.h
+++ b/lodepng.h
@@ -1964,6 +1964,8 @@ state.decoder.zlibsettings.custom_...: use custom inflate function
 state.decoder.ignore_crc: ignore CRC checksums
 state.decoder.ignore_critical: ignore unknown critical chunks
 state.decoder.ignore_end: ignore missing IEND chunk. May fail if this corruption causes other errors
+state.decoder.ignore_invalid_name: do not generate error on invalid names on chunk types
+state.decoder.ignore_reserved_name: do not generate error on reserved names on chunck types
 state.decoder.color_convert: convert internal PNG color to chosen one
 state.decoder.read_text_chunks: whether to read in text metadata chunks
 state.decoder.remember_unknown_chunks: whether to read in unknown chunks
@@ -1987,6 +1989,8 @@ state.encoder.filter_strategy: PNG filter strategy to encode with
 state.encoder.force_palette: add palette even if not encoding to one
 state.encoder.add_id: add LodePNG identifier and version as a text chunk
 state.encoder.text_compression: use compressed text chunks for metadata
+state.encoder.ignore_invalid_name: do not generate error on invalid names on chunk types
+state.encoder.ignore_reserved_name: do not generate error on reserved names on chunck types
 state.info_raw.colortype: color type of raw input image you provide
 state.info_raw.bitdepth: bit depth of raw input image you provide
 state.info_raw: more color settings, see struct LodePNGColorMode


### PR DESCRIPTION
Chunk names can only contain the characters A-Z and a-z, and the 3rd character can never be lower case, as this marks the chunk as reserved for further use in the PNG standard.
But there are some non-compliant files that need to be read, and sometimes, written, which break these rules.
Let's implement flags on the encoder and decoder settings to ignore these checks, but they are enabled by default.