### PR TITLE
Embedded null support on all text chunks

### DIFF
--- a/lodepng.h
+++ b/lodepng.h
@@ -550,6 +550,7 @@ typedef struct LodePNGInfo {
   char** itext_langtags; /*language tag for this text's language, ISO/IEC 646 string, e.g. ISO 639 language tag*/
   char** itext_transkeys; /*keyword translated to the international language - UTF-8 string*/
   char** itext_strings; /*the actual international text - UTF-8 string*/
+  size_t* itext_sizes; /*the actual size of the international text - UTF-8 string, including embedded NULL, excluding terminator NULL*/
 
   /*
   Optional exif metadata in exif_size bytes.
@@ -783,6 +784,8 @@ void lodepng_clear_text(LodePNGInfo* info); /*use this to clear the texts again 
 
 unsigned lodepng_add_itext(LodePNGInfo* info, const char* key, const char* langtag,
                            const char* transkey, const char* str); /*push back the 4 texts of 1 chunk at once*/
+unsigned lodepng_add_itext_sized(LodePNGInfo* info, const char* key, const char* langtag,
+                           const char* transkey, const char* str, size_t size); /*push back the 4 texts of 1 chunk at once*/
 void lodepng_clear_itext(LodePNGInfo* info); /*use this to clear the itexts again after you filled them in*/
 
 /*replaces if exists*/

--- a/lodepng_unittest.cpp
+++ b/lodepng_unittest.cpp
@@ -1299,7 +1299,7 @@ void createComplexPNG(std::vector<unsigned char>& png, int compress) {
   lodepng_add_text_sized(&info, "key1", "string1\0string2", 15);
 
   lodepng_add_itext(&info, "ikey0", "ilangtag0", "itranskey0", "istring0");
-  lodepng_add_itext(&info, "ikey1", "ilangtag1", "itranskey1", "istring1");
+  lodepng_add_itext_sized(&info, "ikey1", "ilangtag1", "itranskey1", "istring1\0istring2", 17);
 
   info.time_defined = 1;
   info.time.year = 2012;
@@ -1388,7 +1388,7 @@ void testComplexPNGNoTextCompression() {
     ASSERT_STRING_EQUALS("ikey1", info.itext_keys[1]);
     ASSERT_STRING_EQUALS("ilangtag1", info.itext_langtags[1]);
     ASSERT_STRING_EQUALS("itranskey1", info.itext_transkeys[1]);
-    ASSERT_STRING_EQUALS("istring1", info.itext_strings[1]);
+    ASSERT_STRING_EQUALS(std::string("istring1\0istring2", 17), std::string(info.itext_strings[1], info.itext_sizes[1]));
 
 
     // TODO: test if unknown chunks listed too
@@ -1462,7 +1462,7 @@ void testComplexPNGTextCompression() {
     ASSERT_STRING_EQUALS("ikey1", info.itext_keys[1]);
     ASSERT_STRING_EQUALS("ilangtag1", info.itext_langtags[1]);
     ASSERT_STRING_EQUALS("itranskey1", info.itext_transkeys[1]);
-    ASSERT_STRING_EQUALS("istring1", info.itext_strings[1]);
+    ASSERT_STRING_EQUALS(std::string("istring1\0istring2", 17), std::string(info.itext_strings[1], info.itext_sizes[1]));
 
 
     // TODO: test if unknown chunks listed too


### PR DESCRIPTION
Although tEXt, zTXt and iTXt are all supposed to have only strings, some applications use them with embedded NULL.
Added `info.text_sizes` and `info.itext_sizes` to keep track of the full size of the decoded strings.
Exported `lodepng_add_text_sized` and `lodepng_add_itext_sized` to allow the creation of strings with embedded null characters.